### PR TITLE
Fix sensitive field exposure in post repository

### DIFF
--- a/repository/postRepository.js
+++ b/repository/postRepository.js
@@ -2,7 +2,11 @@ const Post = require("../models/Post");
 
 const createPost = async (data) => await Post.create(data);
 const getAllPosts = async () => await Post.find().populate("author", "username").populate("category", "name");
-const getPostById = async (id) => await Post.findById(id).populate("author").populate("category");
+// Do not expose sensitive user fields when populating author
+const getPostById = async (id) =>
+  await Post.findById(id)
+    .populate("author", "username")
+    .populate("category", "name");
 const updatePost = async (id, data) => await Post.findByIdAndUpdate(id, data, { new: true });
 const deletePost = async (id) => await Post.findByIdAndDelete(id);
 

--- a/tests/postRepository.test.js
+++ b/tests/postRepository.test.js
@@ -1,0 +1,20 @@
+const Post = require("../models/Post");
+const PostRepository = require("../repository/postRepository");
+
+jest.mock("../models/Post");
+
+describe("postRepository.getPostById", () => {
+  it("populates author username and category name", async () => {
+    const resultData = { title: "sample" };
+    const populateCategory = jest.fn().mockResolvedValue(resultData);
+    const populateAuthor = jest.fn(() => ({ populate: populateCategory }));
+    Post.findById.mockReturnValue({ populate: populateAuthor });
+
+    const result = await PostRepository.getPostById("123");
+
+    expect(Post.findById).toHaveBeenCalledWith("123");
+    expect(populateAuthor).toHaveBeenCalledWith("author", "username");
+    expect(populateCategory).toHaveBeenCalledWith("category", "name");
+    expect(result).toBe(resultData);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid populating user password when fetching posts by id
- add regression test for `getPostById`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848553f47c8832d9f4a3f75df2d93da